### PR TITLE
feat: add pipeline support for logout flow

### DIFF
--- a/lib/samly/idp_data.ex
+++ b/lib/samly/idp_data.ex
@@ -16,6 +16,7 @@ defmodule Samly.IdpData do
             metadata_file: nil,
             metadata: nil,
             pre_session_create_pipeline: nil,
+            post_session_cleanup_pipeline: nil,
             use_redirect_for_req: false,
             sign_requests: true,
             sign_metadata: true,
@@ -44,6 +45,7 @@ defmodule Samly.IdpData do
           metadata_file: nil | binary(),
           metadata: nil | binary(),
           pre_session_create_pipeline: nil | module(),
+          post_session_cleanup_pipeline: nil | module(),
           use_redirect_for_req: boolean(),
           sign_requests: boolean(),
           sign_metadata: boolean(),
@@ -199,8 +201,12 @@ defmodule Samly.IdpData do
 
   @spec set_pipeline(%IdpData{}, map()) :: %IdpData{}
   defp set_pipeline(%IdpData{} = idp_data, %{} = opts_map) do
-    pipeline = Map.get(opts_map, :pre_session_create_pipeline)
-    %IdpData{idp_data | pre_session_create_pipeline: pipeline}
+    pre_pipeline = Map.get(opts_map, :pre_session_create_pipeline)
+    post_pipeline = Map.get(opts_map, :post_session_cleanup_pipeline)
+
+    idp_data
+    |> Map.put(:pre_session_create_pipeline, pre_pipeline)
+    |> Map.put(:post_session_cleanup_pipeline, post_pipeline)
   end
 
   defp set_allowed_target_urls(%IdpData{} = idp_data, %{} = opts_map) do

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Samly.Mixfile do
 
   @version "1.4.0"
   @description "SAML Single-Sign-On Authentication for Plug/Phoenix Applications"
-  @source_url "https://github.com/dropbox/samly"
+  @source_url "https://github.com/workera-ai/elixir_samly/tree/main"
 
   def project() do
     [
@@ -12,7 +12,7 @@ defmodule Samly.Mixfile do
       description: @description,
       docs: docs(),
       package: package(),
-      elixir: "~> 1.10",
+      elixir: "~> 1.17",
       start_permanent: Mix.env() == :prod,
       deps: deps()
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Samly.Mixfile do
   use Mix.Project
 
-  @version "1.4.0"
+  @version "1.5.0"
   @description "SAML Single-Sign-On Authentication for Plug/Phoenix Applications"
   @source_url "https://github.com/workera-ai/elixir_samly/tree/main"
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
 %{
-  "cowboy": {:hex, :cowboy, "2.11.0", "356bf784599cf6f2cdc6ad12fdcfb8413c2d35dab58404cf000e1feaed3f5645", [:make, :rebar3], [{:cowlib, "2.12.1", [hex: :cowlib, repo: "hexpm", optional: false]}, {:ranch, "1.8.0", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm", "0fa395437f1b0e104e0e00999f39d2ac5f4082ac5049b67a5b6d56ecc31b1403"},
-  "cowlib": {:hex, :cowlib, "2.12.1", "a9fa9a625f1d2025fe6b462cb865881329b5caff8f1854d1cbc9f9533f00e1e1", [:make, :rebar3], [], "hexpm", "163b73f6367a7341b33c794c4e88e7dbfe6498ac42dcd69ef44c5bc5507c8db0"},
+  "cowboy": {:hex, :cowboy, "2.12.0", "f276d521a1ff88b2b9b4c54d0e753da6c66dd7be6c9fca3d9418b561828a3731", [:make, :rebar3], [{:cowlib, "2.13.0", [hex: :cowlib, repo: "hexpm", optional: false]}, {:ranch, "1.8.0", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm", "8a7abe6d183372ceb21caa2709bec928ab2b72e18a3911aa1771639bef82651e"},
+  "cowlib": {:hex, :cowlib, "2.13.0", "db8f7505d8332d98ef50a3ef34b34c1afddec7506e4ee4dd4a3a266285d282ca", [:make, :rebar3], [], "hexpm", "e1e1284dc3fc030a64b1ad0d8382ae7e99da46c3246b815318a4b848873800a4"},
   "dialyxir": {:hex, :dialyxir, "1.4.3", "edd0124f358f0b9e95bfe53a9fcf806d615d8f838e2202a9f430d59566b6b53b", [:mix], [{:erlex, ">= 0.2.6", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm", "bf2cfb75cd5c5006bec30141b131663299c661a864ec7fbbc72dfa557487a986"},
   "earmark_parser": {:hex, :earmark_parser, "1.4.39", "424642f8335b05bb9eb611aa1564c148a8ee35c9c8a8bba6e129d51a3e3c6769", [:mix], [], "hexpm", "06553a88d1f1846da9ef066b87b57c6f605552cfbe40d20bd8d59cc6bde41944"},
   "erlex": {:hex, :erlex, "0.2.6", "c7987d15e899c7a2f34f5420d2a2ea0d659682c06ac607572df55a43753aa12e", [:mix], [], "hexpm", "2ed2e25711feb44d52b17d2780eabf998452f6efda104877a3881c2f8c0c0c75"},

--- a/test/samly_idp_data_test.exs
+++ b/test/samly_idp_data_test.exs
@@ -165,6 +165,13 @@ defmodule SamlyIdpDataTest do
     assert idp_data.valid?
   end
 
+  test "valid-idp-config-12", %{sps: sps} do
+    idp_config = Map.put(@idp_config1, :post_session_cleanup_pipeline, MyPipeline)
+    %IdpData{} = idp_data = IdpData.load_provider(idp_config, sps)
+    assert idp_data.valid?
+    assert idp_data.post_session_cleanup_pipeline == MyPipeline
+  end
+
   test "url-test-1", %{sps: sps} do
     idp_config = %{@idp_config1 | metadata_file: "test/data/shibboleth_idp_metadata.xml"}
     %IdpData{} = idp_data = IdpData.load_provider(idp_config, sps)


### PR DESCRIPTION
## Summary
This PR introduces the new IDP configuration `post_session_cleanup_pipeline` which allows a developer to configure a pipeline for the logout flow. This enables the capability of tapping into the logout flow (both SP and IDP initiated) and perform additional cleanup and/or side effects.