### PR TITLE
fix: single log out (SLO) flow not working due to assertion being "expired" 

### DIFF
--- a/lib/samly.ex
+++ b/lib/samly.ex
@@ -8,7 +8,7 @@ defmodule Samly do
   alias Samly.{Assertion, State}
 
   @doc """
-  Returns authenticated user SAML Assertion.
+  Returns authenticated user SAML Assertion which is not expired.
 
   The struct includes the attributes sent from IdP as well as any corresponding locally
   computed/derived attributes. Returns `nil` if the current Plug session
@@ -25,12 +25,38 @@ defmodule Samly do
   """
   @spec get_active_assertion(Conn.t()) :: nil | Assertion.t()
   def get_active_assertion(conn) do
-    with {_idp_id, _nameid} = assertion_key <- Conn.get_session(conn, "samly_assertion_key"),
-         %Assertion{} = assertion <- State.get_assertion(conn, assertion_key),
+    with %Assertion{} = assertion <- get_assertion(conn),
          :valid <- StateUtil.validate_login_assertion_expiry(assertion) do
       assertion
     else
       _ -> nil
+    end
+  end
+
+  @doc """
+  Returns authenticated user SAML Assertion, no matter if it's expired or not.
+
+  The struct includes the attributes sent from IdP as well as any corresponding locally
+  computed/derived attributes. Returns `nil` if the current Plug session
+  is not authenticated.
+
+  ## Parameters
+
+  +   `conn` - Plug connection
+
+  ## Examples
+
+      # When there is an authenticated SAML assertion
+      %Assertion{} = Samly.get_active_assertion()
+  """
+  @spec get_assertion(Conn.t()) :: nil | Assertion.t()
+  def get_assertion(conn) do
+    case Conn.get_session(conn, "samly_assertion_key") do
+      {_idp_id, _nameid} = assertion_key ->
+        State.get_assertion(conn, assertion_key)
+
+      _ ->
+        nil
     end
   end
 

--- a/lib/samly/state/ets.ex
+++ b/lib/samly/state/ets.ex
@@ -46,8 +46,11 @@ defmodule Samly.State.ETS do
   @impl Samly.State.Store
   def get_assertion(_conn, assertion_key, assertions_table) do
     case :ets.lookup(assertions_table, assertion_key) do
-      [{^assertion_key, %Assertion{} = assertion}] -> validate_assertion_expiry(assertion)
-      _ -> nil
+      [{^assertion_key, %Assertion{} = assertion}] ->
+        assertion
+
+      _ ->
+        nil
     end
   end
 
@@ -61,19 +64,5 @@ defmodule Samly.State.ETS do
   def delete_assertion(conn, assertion_key, assertions_table) do
     :ets.delete(assertions_table, assertion_key)
     conn
-  end
-
-  defp validate_assertion_expiry(
-         %Assertion{subject: %{notonorafter: not_on_or_after}} = assertion
-       ) do
-    now = DateTime.utc_now()
-
-    case DateTime.from_iso8601(not_on_or_after) do
-      {:ok, not_on_or_after, _} ->
-        if DateTime.compare(now, not_on_or_after) == :lt, do: assertion, else: nil
-
-      _ ->
-        nil
-    end
   end
 end

--- a/lib/samly/state/session.ex
+++ b/lib/samly/state/session.ex
@@ -34,8 +34,11 @@ defmodule Samly.State.Session do
     %{key: key} = opts
 
     case Conn.get_session(conn, key) do
-      {^assertion_key, %Assertion{} = assertion} -> validate_assertion_expiry(assertion)
-      _ -> nil
+      {^assertion_key, %Assertion{} = assertion} ->
+        assertion
+
+      _ ->
+        nil
     end
   end
 
@@ -49,19 +52,5 @@ defmodule Samly.State.Session do
   def delete_assertion(conn, _assertion_key, opts) do
     %{key: key} = opts
     Conn.delete_session(conn, key)
-  end
-
-  defp validate_assertion_expiry(
-         %Assertion{subject: %{notonorafter: not_on_or_after}} = assertion
-       ) do
-    now = DateTime.utc_now()
-
-    case DateTime.from_iso8601(not_on_or_after) do
-      {:ok, not_on_or_after, _} ->
-        if DateTime.compare(now, not_on_or_after) == :lt, do: assertion, else: nil
-
-      _ ->
-        nil
-    end
   end
 end

--- a/lib/samly/state/state_util.ex
+++ b/lib/samly/state/state_util.ex
@@ -1,0 +1,30 @@
+defmodule Samly.State.StateUtil do
+  @moduledoc false
+
+  alias Samly.Assertion
+
+  def validate_assertion_expiry(%Assertion{} = assertion, :login = _phase) do
+    expiry_date = assertion.subject.notonorafter
+
+    if has_date_passed?(expiry_date), do: nil, else: assertion
+  end
+
+  def validate_assertion_expiry(%Assertion{} = assertion, :logout = _phase) do
+    expiry_date =
+      Map.get(assertion.authn, "session_not_on_or_after", assertion.subject.notonorafter)
+
+    if has_date_passed?(expiry_date), do: nil, else: assertion
+  end
+
+  defp has_date_passed?(expiry_date) do
+    now = DateTime.utc_now()
+
+    case DateTime.from_iso8601(expiry_date) do
+      {:ok, expiry_date, _} ->
+        if DateTime.compare(now, expiry_date) == :lt, do: false, else: true
+
+      _ ->
+        true
+    end
+  end
+end

--- a/lib/samly/state/state_util.ex
+++ b/lib/samly/state/state_util.ex
@@ -3,10 +3,12 @@ defmodule Samly.State.StateUtil do
 
   alias Samly.Assertion
 
+  @spec validate_login_assertion_expiry(Assertion.t()) :: :valid | :expired
   def validate_login_assertion_expiry(%Assertion{subject: %{notonorafter: expiry_date}}) do
     if date_passed?(expiry_date), do: :expired, else: :valid
   end
 
+  @spec validate_logout_assertion_expiry(Assertion.t()) :: :valid | :expired
   def validate_logout_assertion_expiry(%Assertion{authn: authn, subject: subject}) do
     expiry_date =
       Map.get(authn, "session_not_on_or_after", subject.notonorafter)

--- a/lib/samly/state/state_util.ex
+++ b/lib/samly/state/state_util.ex
@@ -3,20 +3,18 @@ defmodule Samly.State.StateUtil do
 
   alias Samly.Assertion
 
-  def validate_assertion_expiry(%Assertion{} = assertion, :login = _phase) do
-    expiry_date = assertion.subject.notonorafter
-
-    if has_date_passed?(expiry_date), do: nil, else: assertion
+  def validate_login_assertion_expiry(%Assertion{subject: %{notonorafter: expiry_date}}) do
+    if date_passed?(expiry_date), do: :expired, else: :valid
   end
 
-  def validate_assertion_expiry(%Assertion{} = assertion, :logout = _phase) do
+  def validate_logout_assertion_expiry(%Assertion{authn: authn, subject: subject}) do
     expiry_date =
-      Map.get(assertion.authn, "session_not_on_or_after", assertion.subject.notonorafter)
+      Map.get(authn, "session_not_on_or_after", subject.notonorafter)
 
-    if has_date_passed?(expiry_date), do: nil, else: assertion
+    if date_passed?(expiry_date), do: :expired, else: :valid
   end
 
-  defp has_date_passed?(expiry_date) do
+  defp date_passed?(expiry_date) do
     now = DateTime.utc_now()
 
     case DateTime.from_iso8601(expiry_date) do

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Samly.Mixfile do
   use Mix.Project
 
-  @version "1.5.0"
+  @version "1.6.0"
   @description "SAML Single-Sign-On Authentication for Plug/Phoenix Applications"
   @source_url "https://github.com/workera-ai/elixir_samly/tree/main"
 

--- a/test/samly_state_test.exs
+++ b/test/samly_state_test.exs
@@ -2,6 +2,8 @@ defmodule Samly.StateTest do
   use ExUnit.Case, async: true
   use Plug.Test
 
+  alias Samly.State.StateUtil
+
   describe "With Session Cache" do
     setup do
       opts =
@@ -39,10 +41,19 @@ defmodule Samly.StateTest do
     end
 
     test "get failure for expired assertion key", %{conn: conn} do
+      # Arrange
       assertion = %Samly.Assertion{}
       assertion_key = {"idp1", "name1"}
-      conn = Samly.State.put_assertion(conn, assertion_key, assertion)
-      assert is_nil(Samly.State.get_assertion(conn, {"idp1", "name1"}))
+
+      # Act
+      result =
+        conn
+        |> Samly.State.put_assertion(assertion_key, assertion)
+        |> Samly.State.get_assertion(assertion_key)
+        |> StateUtil.validate_login_assertion_expiry()
+
+      # Assert
+      assert result == :expired
     end
 
     test "delete assertion", %{conn: conn} do
@@ -78,10 +89,19 @@ defmodule Samly.StateTest do
     end
 
     test "get failure for expired assertion key", %{conn: conn} do
+      # Arrange
       assertion = %Samly.Assertion{}
       assertion_key = {"idp1", "name1"}
-      conn = Samly.State.put_assertion(conn, assertion_key, assertion)
-      assert is_nil(Samly.State.get_assertion(conn, {"idp1", "name1"}))
+
+      # Act
+      result =
+        conn
+        |> Samly.State.put_assertion(assertion_key, assertion)
+        |> Samly.State.get_assertion(assertion_key)
+        |> StateUtil.validate_login_assertion_expiry()
+
+      # Assert
+      assert result == :expired
     end
 
     test "delete assertion", %{conn: conn} do

--- a/test/state_util_test.exs
+++ b/test/state_util_test.exs
@@ -1,0 +1,119 @@
+defmodule Samly.StateUtilTest do
+  @moduledoc false
+
+  use ExUnit.Case, async: true
+  use Plug.Test
+
+  alias Samly.Assertion
+  alias Samly.State.StateUtil
+
+  describe "validate_assertion_expiry/2" do
+    test "returns nil when assertion is expired for login request" do
+      # Arrange
+      not_on_or_after = DateTime.utc_now() |> DateTime.add(-8, :hour) |> DateTime.to_iso8601()
+
+      session_not_on_or_after =
+        DateTime.utc_now() |> DateTime.add(8, :hour) |> DateTime.to_iso8601()
+
+      assertion = %Samly.Assertion{
+        subject: %{notonorafter: not_on_or_after},
+        authn: %{"session_not_on_or_after" => session_not_on_or_after}
+      }
+
+      # Act
+      result = StateUtil.validate_assertion_expiry(assertion, :login)
+
+      # Assert
+      assert result == nil
+    end
+
+    test "returns assertion when assertion has not expired for login request" do
+      # Arrange
+      not_on_or_after = DateTime.utc_now() |> DateTime.add(8, :hour) |> DateTime.to_iso8601()
+
+      session_not_on_or_after =
+        DateTime.utc_now() |> DateTime.add(8, :hour) |> DateTime.to_iso8601()
+
+      assertion = %Samly.Assertion{
+        subject: %{notonorafter: not_on_or_after},
+        authn: %{"session_not_on_or_after" => session_not_on_or_after}
+      }
+
+      # Act
+      result = StateUtil.validate_assertion_expiry(assertion, :login)
+
+      # Assert
+      assert result == assertion
+    end
+
+    test "returns nil when assertion is expired for logout request" do
+      # Arrange
+      not_on_or_after = DateTime.utc_now() |> DateTime.add(8, :hour) |> DateTime.to_iso8601()
+
+      session_not_on_or_after =
+        DateTime.utc_now() |> DateTime.add(-8, :hour) |> DateTime.to_iso8601()
+
+      assertion = %Samly.Assertion{
+        subject: %{notonorafter: not_on_or_after},
+        authn: %{"session_not_on_or_after" => session_not_on_or_after}
+      }
+
+      # Act
+      result = StateUtil.validate_assertion_expiry(assertion, :logout)
+
+      # Assert
+      assert result == nil
+    end
+
+    test "returns assertion when assertion has not expired for logout request" do
+      # Arrange
+      not_on_or_after = DateTime.utc_now() |> DateTime.add(8, :hour) |> DateTime.to_iso8601()
+
+      session_not_on_or_after =
+        DateTime.utc_now() |> DateTime.add(8, :hour) |> DateTime.to_iso8601()
+
+      assertion = %Samly.Assertion{
+        subject: %{notonorafter: not_on_or_after},
+        authn: %{"session_not_on_or_after" => session_not_on_or_after}
+      }
+
+      # Act
+      result = StateUtil.validate_assertion_expiry(assertion, :logout)
+
+      # Assert
+      assert result == assertion
+    end
+
+    test "returns nil when session_not_on_or_after is not available but assertion subject has also expired for logout request" do
+      # Arrange
+      not_on_or_after = DateTime.utc_now() |> DateTime.add(-8, :hour) |> DateTime.to_iso8601()
+
+      assertion = %Samly.Assertion{
+        subject: %{notonorafter: not_on_or_after},
+        authn: %{}
+      }
+
+      # Act
+      result = StateUtil.validate_assertion_expiry(assertion, :logout)
+
+      # Assert
+      assert result == nil
+    end
+
+    test "returns assertion when session_not_on_or_after is not available but assertion subject has not expired for logout request" do
+      # Arrange
+      not_on_or_after = DateTime.utc_now() |> DateTime.add(8, :hour) |> DateTime.to_iso8601()
+
+      assertion = %Samly.Assertion{
+        subject: %{notonorafter: not_on_or_after},
+        authn: %{}
+      }
+
+      # Act
+      result = StateUtil.validate_assertion_expiry(assertion, :logout)
+
+      # Assert
+      assert result == assertion
+    end
+  end
+end

--- a/test/state_util_test.exs
+++ b/test/state_util_test.exs
@@ -4,11 +4,10 @@ defmodule Samly.StateUtilTest do
   use ExUnit.Case, async: true
   use Plug.Test
 
-  alias Samly.Assertion
   alias Samly.State.StateUtil
 
-  describe "validate_assertion_expiry/2" do
-    test "returns nil when assertion is expired for login request" do
+  describe "validate_login_assertion_expiry/1" do
+    test "is :expired when assertion is expired" do
       # Arrange
       not_on_or_after = DateTime.utc_now() |> DateTime.add(-8, :hour) |> DateTime.to_iso8601()
 
@@ -21,13 +20,13 @@ defmodule Samly.StateUtilTest do
       }
 
       # Act
-      result = StateUtil.validate_assertion_expiry(assertion, :login)
+      result = StateUtil.validate_login_assertion_expiry(assertion)
 
       # Assert
-      assert result == nil
+      assert result == :expired
     end
 
-    test "returns assertion when assertion has not expired for login request" do
+    test "is :valid when assertion has not expired for" do
       # Arrange
       not_on_or_after = DateTime.utc_now() |> DateTime.add(8, :hour) |> DateTime.to_iso8601()
 
@@ -40,13 +39,15 @@ defmodule Samly.StateUtilTest do
       }
 
       # Act
-      result = StateUtil.validate_assertion_expiry(assertion, :login)
+      result = StateUtil.validate_login_assertion_expiry(assertion)
 
       # Assert
-      assert result == assertion
+      assert result == :valid
     end
+  end
 
-    test "returns nil when assertion is expired for logout request" do
+  describe "validate_logout_assertion_expiry/1" do
+    test "is :expired when assertion is expired" do
       # Arrange
       not_on_or_after = DateTime.utc_now() |> DateTime.add(8, :hour) |> DateTime.to_iso8601()
 
@@ -59,15 +60,15 @@ defmodule Samly.StateUtilTest do
       }
 
       # Act
-      result = StateUtil.validate_assertion_expiry(assertion, :logout)
+      result = StateUtil.validate_logout_assertion_expiry(assertion)
 
       # Assert
-      assert result == nil
+      assert result == :expired
     end
 
-    test "returns assertion when assertion has not expired for logout request" do
+    test "is :valid when assertion has not expired" do
       # Arrange
-      not_on_or_after = DateTime.utc_now() |> DateTime.add(8, :hour) |> DateTime.to_iso8601()
+      not_on_or_after = DateTime.utc_now() |> DateTime.add(-8, :hour) |> DateTime.to_iso8601()
 
       session_not_on_or_after =
         DateTime.utc_now() |> DateTime.add(8, :hour) |> DateTime.to_iso8601()
@@ -78,13 +79,13 @@ defmodule Samly.StateUtilTest do
       }
 
       # Act
-      result = StateUtil.validate_assertion_expiry(assertion, :logout)
+      result = StateUtil.validate_logout_assertion_expiry(assertion)
 
       # Assert
-      assert result == assertion
+      assert result == :valid
     end
 
-    test "returns nil when session_not_on_or_after is not available but assertion subject has also expired for logout request" do
+    test "is :expired when session_not_on_or_after is missing and assertion subject has also expired" do
       # Arrange
       not_on_or_after = DateTime.utc_now() |> DateTime.add(-8, :hour) |> DateTime.to_iso8601()
 
@@ -94,13 +95,13 @@ defmodule Samly.StateUtilTest do
       }
 
       # Act
-      result = StateUtil.validate_assertion_expiry(assertion, :logout)
+      result = StateUtil.validate_logout_assertion_expiry(assertion)
 
       # Assert
-      assert result == nil
+      assert result == :expired
     end
 
-    test "returns assertion when session_not_on_or_after is not available but assertion subject has not expired for logout request" do
+    test "is :valid when session_not_on_or_after is missing but assertion subject has not expired" do
       # Arrange
       not_on_or_after = DateTime.utc_now() |> DateTime.add(8, :hour) |> DateTime.to_iso8601()
 
@@ -110,10 +111,10 @@ defmodule Samly.StateUtilTest do
       }
 
       # Act
-      result = StateUtil.validate_assertion_expiry(assertion, :logout)
+      result = StateUtil.validate_logout_assertion_expiry(assertion)
 
       # Assert
-      assert result == assertion
+      assert result == :valid
     end
   end
 end


### PR DESCRIPTION
## Summary
When initiating SLO flow we are checking if the assertion has expired.
This is good security practice when it comes to validating the validity of the authentication request. However, when dealing with logout which can happen much later into the users active session, we cannot validate agains the same assertion subject key.

## Solution
This PR exposes a new `StateUtil` module which exposes two functions for validating the expire date on the Assertion. For auth requests we perform the same check as of today but for SLO requests we now call `StateUtil.validate_logout_assertion_expiry/1` which checks the `Assertion.Authn.session_not_on_or_after` property, which is provided by the IDP and tells the service provider (SP) for how long a session is expected to live.