### PR TITLE
fix: samly state fails on getting assertion from Redis [her-93]

### DIFF
--- a/lib/samly/state/redis.ex
+++ b/lib/samly/state/redis.ex
@@ -96,7 +96,7 @@ defmodule Samly.State.Redis do
       {:ok, binary} when is_binary(binary) ->
         binary
         |> Base.decode64!()
-        |> :erlang.binary_to_term(:safe)
+        |> :erlang.binary_to_term([:safe])
 
       {:error, reason} ->
         raise "Failed to get assertion from Redis: #{inspect(reason)}"

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Samly.Mixfile do
   use Mix.Project
 
-  @version "1.7.1"
+  @version "1.7.2"
   @description "SAML Single-Sign-On Authentication for Plug/Phoenix Applications"
   @source_url "https://github.com/workera-ai/elixir_samly/tree/main"
 


### PR DESCRIPTION
The `:safe` option needs to be passed within a list of options.

https://www.erlang.org/doc/apps/erts/erlang.html#binary_to_term/2

```
-spec binary_to_term(Binary, Opts) -> [term](https://www.erlang.org/doc/apps/erts/erlang.html#t:term/0)() | {[term](https://www.erlang.org/doc/apps/erts/erlang.html#t:term/0)(), Used}
                        when
                            Binary :: [ext_binary](https://www.erlang.org/doc/apps/erts/erlang.html#t:ext_binary/0)(),
                            Opt :: safe | used,
                            Opts :: [Opt],
                            Used :: [pos_integer](https://www.erlang.org/doc/apps/erts/erlang.html#t:pos_integer/0)().
```